### PR TITLE
Update get_entity_from_part return type

### DIFF
--- a/src/jabby/index.d.ts
+++ b/src/jabby/index.d.ts
@@ -8,7 +8,7 @@ interface Applet<T> {
 interface WorldConfig {
     world: World,
     entities?: Map<Instance, Entity>,
-    get_entity_from_part?: ((part: BasePart) => LuaTuple<[Entity, Part]>)
+    get_entity_from_part?: ((part: BasePart) => LuaTuple<[Entity, Instance]> | undefined)
 }
 
 interface SchedulerConfig {

--- a/src/jabby/index.d.ts
+++ b/src/jabby/index.d.ts
@@ -8,7 +8,7 @@ interface Applet<T> {
 interface WorldConfig {
     world: World,
     entities?: Map<Instance, Entity>,
-    get_entity_from_part?: ((part: BasePart) => LuaTuple<[Entity, Instance]> | undefined)
+    get_entity_from_part?: ((part: BasePart) => LuaTuple<[Entity, PVInstance]> | undefined)
 }
 
 interface SchedulerConfig {


### PR DESCRIPTION
Fixing get_entity_from_part's return type to allow for an undefined return as well as any instance rather than specifically a part